### PR TITLE
Front/feat/기능 고도화

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,9 @@
-import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Outlet,
+  useLocation,
+} from "react-router-dom";
 import { Suspense, useEffect } from "react";
 import ParticleBackground from "./shared/components/Visualizer/ParticleBackground";
 import Header from "./shared/components/Header/Header";
@@ -37,6 +42,9 @@ import SituationResult from "./pages/SituationPractice/SituationResultPage";
 
 // 레이아웃 컴포넌트 생성
 const Layout = () => {
+  const location = useLocation();
+  const showHeader = location.pathname !== "/user-info";
+
   const setSelectedColor = useHistoryColorStore(
     (state) => state.setSelectedColor
   );
@@ -81,7 +89,7 @@ const Layout = () => {
     <>
       <ParticleBackground />
       <NotificationListener />
-      <Header />
+      {showHeader && <Header />}
       <ToastContainer />
       <Suspense fallback={<div></div>}>
         <Outlet />

--- a/frontend/src/pages/Lecture/LecturePage.tsx
+++ b/frontend/src/pages/Lecture/LecturePage.tsx
@@ -151,7 +151,7 @@ export default function LecturePage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-transparent text-white">
+    <div className="min-h-[calc(100vh-4rem)] bg-transparent text-white">
       <Box sx={{ maxWidth: "1200px", margin: "0 auto" }}>
         {error && (
           <div className="text-red-500 mb-4 p-4 bg-red-500/10 rounded">

--- a/frontend/src/pages/Login/AccessPage.tsx
+++ b/frontend/src/pages/Login/AccessPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import useAuthStore from "../../shared/stores/authStore";
+import { jwtDecode } from "jwt-decode";
 
 function Access() {
   const setToken = useAuthStore((state) => state.setToken);
@@ -11,7 +12,19 @@ function Access() {
     if (token) {
       console.log("토큰 발견:", token);
       setToken(token);
-      window.location.replace("/user-info");
+
+      // 토큰 디코딩 후 gender 확인
+      try {
+        const tokenData = jwtDecode<{ gender: string }>(token);
+        if (tokenData.gender === "male" || tokenData.gender === "female") {
+          window.location.replace("/");
+        } else {
+          window.location.replace("/user-info");
+        }
+      } catch (error) {
+        console.error("토큰 처리 중 오류:", error);
+        window.location.replace("/login");
+      }
     } else {
       console.log("토큰을 찾을 수 없습니다");
       window.location.replace("/login");

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -13,6 +13,8 @@ function UserInfoRegistPage() {
   // useEffect 사용시 DOM 렌더링 후 처리되므로 UserInfoPage가 보이고 깜빡임.
   // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
   useLayoutEffect(() => {
+    console.log(userProfile);
+    console.log(userProfile.gender);
     if (userProfile.gender !== "None" && userProfile.gender) {
       navigate("/");
     }

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -13,7 +13,7 @@ function UserInfoRegistPage() {
   // useEffect 사용시 DOM 렌더링 후 처리되므로 UserInfoPage가 보이고 깜빡임.
   // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
   useLayoutEffect(() => {
-    if (userProfile.gender !== "None" && userProfile.gender) {
+    if (userProfile?.gender && userProfile.gender !== "None") {
       navigate("/");
     }
   }, [userProfile, navigate]);

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -14,14 +14,21 @@ function UserInfoRegistPage() {
   // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
   useLayoutEffect(() => {
     if (userProfile?.gender === "male" || userProfile?.gender === "female") {
-      navigate("/");
+      console.log("리다이렉트 시도:", userProfile.gender);
+      navigate("/", { replace: true });
     }
-  }, [userProfile, navigate]);
+  }, [userProfile?.gender, navigate]);
 
   useEffect(() => {
     console.log("현재 유저 프로필:", userProfile);
     console.log("현재 성별:", userProfile.gender);
     console.log("현재 에러:", error);
+    console.log("리다이렉트 조건 확인:", {
+      gender: userProfile?.gender,
+      isMaleOrFemale:
+        userProfile?.gender === "male" || userProfile?.gender === "female",
+      typeof: typeof userProfile?.gender,
+    });
   }, [userProfile, gender, error]);
 
   const refreshAccessToken = async () => {

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from "react";
+import { useState, useLayoutEffect, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import axiosInstance, { tokenRefresh } from "../../services/axiosInstance";
 import useAuthStore from "../../shared/stores/authStore";
@@ -13,12 +13,18 @@ function UserInfoRegistPage() {
   // useEffect 사용시 DOM 렌더링 후 처리되므로 UserInfoPage가 보이고 깜빡임.
   // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
   useLayoutEffect(() => {
-    console.log(userProfile);
-    console.log(userProfile.gender);
     if (userProfile.gender !== "None" && userProfile.gender) {
       navigate("/");
     }
   }, [userProfile, navigate]);
+
+  useEffect(() => {
+    console.log("현재 유저 프로필:", userProfile);
+    console.log("현재 성별:", userProfile.gender);
+    console.log("현재 성별:", gender);
+    console.log("현재 에러:", error);
+  }, [userProfile, gender, error]);
+
   const refreshAccessToken = async () => {
     try {
       await tokenRefresh(); // 토큰 재발급 호출

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -13,7 +13,7 @@ function UserInfoRegistPage() {
   // useEffect 사용시 DOM 렌더링 후 처리되므로 UserInfoPage가 보이고 깜빡임.
   // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
   useLayoutEffect(() => {
-    if (userProfile?.gender && userProfile.gender !== "None") {
+    if (userProfile?.gender === "male" || userProfile?.gender === "female") {
       navigate("/");
     }
   }, [userProfile, navigate]);
@@ -21,7 +21,6 @@ function UserInfoRegistPage() {
   useEffect(() => {
     console.log("현재 유저 프로필:", userProfile);
     console.log("현재 성별:", userProfile.gender);
-    console.log("현재 성별:", gender);
     console.log("현재 에러:", error);
   }, [userProfile, gender, error]);
 
@@ -95,7 +94,7 @@ function UserInfoRegistPage() {
 
           <button
             onClick={handleSubmit}
-            className="w-full px-6 py-3 bg-cyan-500/20 hover:bg-cyan-500/30 
+            className="w-full px-6 py-3 bg-cyan-500W/20 hover:bg-cyan-500/30 
               text-cyan-300 rounded-lg border border-cyan-500/50 
               transition-all duration-300"
           >

--- a/frontend/src/pages/Login/UserInfoRegistPage.tsx
+++ b/frontend/src/pages/Login/UserInfoRegistPage.tsx
@@ -1,35 +1,11 @@
-import { useState, useLayoutEffect, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axiosInstance, { tokenRefresh } from "../../services/axiosInstance";
-import useAuthStore from "../../shared/stores/authStore";
 
 function UserInfoRegistPage() {
   const [gender, setGender] = useState<"male" | "female" | null>(null);
   const [error, setError] = useState("");
   const navigate = useNavigate();
-  const userProfile = useAuthStore((state) => state.userProfile);
-
-  // 필요한 정보가 이미 있다면 메인 페이지로 리다이렉트
-  // useEffect 사용시 DOM 렌더링 후 처리되므로 UserInfoPage가 보이고 깜빡임.
-  // 간단히 라우팅만 하기 때문에 useLayoutEffect 사용하였음.
-  useLayoutEffect(() => {
-    if (userProfile?.gender === "male" || userProfile?.gender === "female") {
-      console.log("리다이렉트 시도:", userProfile.gender);
-      navigate("/", { replace: true });
-    }
-  }, [userProfile?.gender, navigate]);
-
-  useEffect(() => {
-    console.log("현재 유저 프로필:", userProfile);
-    console.log("현재 성별:", userProfile.gender);
-    console.log("현재 에러:", error);
-    console.log("리다이렉트 조건 확인:", {
-      gender: userProfile?.gender,
-      isMaleOrFemale:
-        userProfile?.gender === "male" || userProfile?.gender === "female",
-      typeof: typeof userProfile?.gender,
-    });
-  }, [userProfile, gender, error]);
 
   const refreshAccessToken = async () => {
     try {

--- a/frontend/src/pages/VoiceAnalysis/VoiceAnalysisListPage.tsx
+++ b/frontend/src/pages/VoiceAnalysis/VoiceAnalysisListPage.tsx
@@ -6,9 +6,8 @@ import Pagination from "@mui/material/Pagination";
 import MetricsVisualizer from "../../shared/components/VoiceQuality/MetricsVisualizer";
 import { DeleteIcon } from "../../shared/components/Icons/DeleteIcon";
 import Swal from "sweetalert2";
-import "../SituationPractice/SwalStyles.css"
+import "../SituationPractice/SwalStyles.css";
 import { AnalysisDelete } from "../../services/VoiceAnalysis/VoiceAnalysisPost";
-
 
 function VoiceAnalysisListPage() {
   const navigate = useNavigate();
@@ -16,7 +15,6 @@ function VoiceAnalysisListPage() {
     null
   );
   const [page, setPage] = useState(1);
-  
 
   const fetchAnalysisList = async (pageNum: number) => {
     try {
@@ -46,7 +44,6 @@ function VoiceAnalysisListPage() {
     return "개선 필요";
   };
 
-
   const handleDelete = (recordId: number) => {
     Swal.fire({
       title: "대본을 삭제하시겠습니까?",
@@ -67,9 +64,10 @@ function VoiceAnalysisListPage() {
 
           setAnalysisData((prevData) => ({
             ...prevData!,
-            content: prevData!.content.filter(item => item.recordId !== recordId),
+            content: prevData!.content.filter(
+              (item) => item.recordId !== recordId
+            ),
           }));
-          
         } catch (e) {
           console.log(e);
         }
@@ -90,27 +88,24 @@ function VoiceAnalysisListPage() {
                 className="p-4 border-b border-white/30 hover:bg-white/10 transition-colors cursor-pointer"
                 onClick={() => navigate(`/analysis/${item.recordId}`)}
               >
-                <div className="flex justify-between items-start gap-4">
-                  <div className="flex-1">
-
-
-
-                    <div className="flex justify-between items-center mb-3">
-                      <div className="flex items-center gap-2">
-                          <h3 className="text-xl font-semibold text-white">
-                            {item.title}
-                          </h3>
-                          <DeleteIcon onClick={() => handleDelete(item.recordId)} strokeColor='#4CC9FE' />
+                <div className="flex flex-col lg:flex-row justify-between items-start gap-4">
+                  <div className="flex-1 w-full">
+                    <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center mb-3">
+                      <div className="flex items-center gap-2 mb-2 lg:mb-0">
+                        <h3 className="text-lg lg:text-xl font-semibold text-white">
+                          {item.title}
+                        </h3>
+                        <DeleteIcon
+                          onClick={() => handleDelete(item.recordId)}
+                          strokeColor="#4CC9FE"
+                        />
                       </div>
                       <span className="text-sm text-white/80">
                         {item.createdAt}
                       </span>
                     </div>
 
-
-
-
-                    <div className="flex items-center gap-4">
+                    <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4">
                       <div
                         className={`px-4 py-1.5 rounded-full text-center whitespace-nowrap ${
                           calculateOverallGrade(item.analyzeResult.metrics) ===
@@ -125,7 +120,7 @@ function VoiceAnalysisListPage() {
                       >
                         {calculateOverallGrade(item.analyzeResult.metrics)}
                       </div>
-                      <div className="flex gap-4 text-white/90">
+                      <div className="flex flex-col lg:flex-row gap-2 lg:gap-4 text-white/90 text-sm lg:text-base">
                         <div className="flex items-center gap-2">
                           <span>명료도:</span>
                           <span
@@ -145,7 +140,7 @@ function VoiceAnalysisListPage() {
                             }
                           </span>
                         </div>
-                        <span className="text-white/30">|</span>
+                        <span className="hidden lg:block text-white/30">|</span>
                         <div className="flex items-center gap-2">
                           <span>발화 에너지:</span>
                           <span
@@ -168,7 +163,7 @@ function VoiceAnalysisListPage() {
                             }
                           </span>
                         </div>
-                        <span className="text-white/30">|</span>
+                        <span className="hidden lg:block text-white/30">|</span>
                         <div className="flex items-center gap-2">
                           <span>멜로디:</span>
                           <span
@@ -194,7 +189,7 @@ function VoiceAnalysisListPage() {
                       </div>
                     </div>
                   </div>
-                  <div className="w-[100px] h-[100px] flex-shrink-0">
+                  <div className="w-[80px] h-[80px] lg:w-[100px] lg:h-[100px] flex-shrink-0 mx-auto lg:mx-0">
                     <MetricsVisualizer
                       metrics={item.analyzeResult.metrics}
                       showLabels={false}

--- a/frontend/src/services/axiosInstance.ts
+++ b/frontend/src/services/axiosInstance.ts
@@ -29,29 +29,69 @@ axiosInstance.interceptors.request.use(
   }
 );
 
+let isRefreshing = false; // 토큰 재발급 진행 중 여부
+let failedQueue: any[] = []; // 실패한 요청 큐
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
   function (response: AxiosResponse) {
     return response;
   },
   async (error: AxiosError) => {
-    if (error.response?.status === 401) {
+    const originalRequest = error.config;
+
+    if (!originalRequest) {
+      return Promise.reject(error);
+    }
+
+    // 401 에러이고 토큰 재발급 시도가 아직 안된 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // 이미 토큰 재발급 진행 중이면 대기
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers["Authorization"] = `Bearer ${token}`;
+            return axiosInstance(originalRequest);
+          })
+          .catch((err) => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
       try {
         await tokenRefresh();
-        const token = useAuthStore.getState().token;
-        console.log("엑세스 토큰 재발급 요청", error.response)
+        const newToken = useAuthStore.getState().token;
 
-        if (token && error.config) {
-          // 토큰 재발급 확인을 위한 콘솔 로그
-          // console.log("새 엑세스 토큰 발급", error.config);
-          // error.config.headers.Authorization = `Bearer ${token}`;
-          return axiosInstance(error.config);
+        if (!newToken) {
+          throw new Error("Token refresh failed");
         }
+
+        processQueue(null, newToken);
+        originalRequest.headers["Authorization"] = `Bearer ${newToken}`;
+        return axiosInstance(originalRequest);
       } catch (refreshError) {
+        processQueue(refreshError, null);
         Logout();
         return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
       }
     }
+
     return Promise.reject(error);
   }
 );
@@ -59,16 +99,20 @@ axiosInstance.interceptors.response.use(
 // 리프레쉬 토큰으로 엑세스 토큰 재발급 요청
 const tokenRefresh = async () => {
   const token = useAuthStore.getState().token;
+  if (!token) {
+    throw new Error("No token available");
+  }
 
   try {
     const response = await axios.post(
       `${import.meta.env.VITE_API_URL}/user/public/reissue`,
       {},
       {
-        headers: { "Content-Type": "application/json" ,
-        "Authorization": `Bearer ${token}`,
-        "refreshToken": token
-        }
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          refreshToken: token,
+        },
       }
     );
     // const newAccessToken = response.headers.authorization.replace(
@@ -77,25 +121,20 @@ const tokenRefresh = async () => {
     // );
 
     const newAccessToken = response.data.data;
-    
-
     if (!newAccessToken) {
-      console.log("엑세스 토큰 재발급 실패");
-      return;
+      throw new Error("Token refresh failed");
     }
 
-    // Zustand store를 통해 토큰 저장
     useAuthStore.getState().setToken(newAccessToken);
-  } catch (e) {
-    console.error("리프레시 토큰 요청 중 오류", e);
-    throw e;
+  } catch (error) {
+    console.error("Token refresh failed:", error);
+    throw error;
   }
 };
 
-// 로그아웃
-const Logout = async () => {
+const Logout = () => {
   useAuthStore.getState().setToken(null);
-  window.location.replace("/");
+  window.location.replace("/login"); // 로그인 페이지로 리다이렉트
 };
 
 export default axiosInstance;

--- a/frontend/src/services/axiosInstance.ts
+++ b/frontend/src/services/axiosInstance.ts
@@ -1,5 +1,14 @@
-import axios, { AxiosResponse, AxiosError } from "axios";
+import axios, {
+  AxiosResponse,
+  AxiosError,
+  InternalAxiosRequestConfig,
+} from "axios";
 import useAuthStore from "../shared/stores/authStore";
+
+// 파일 상단에 타입 정의 추가
+interface CustomInternalAxiosRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
 
 // axios 인스턴스 생성
 const axiosInstance = axios.create({
@@ -49,7 +58,7 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   async (error: AxiosError) => {
-    const originalRequest = error.config;
+    const originalRequest = error.config as CustomInternalAxiosRequestConfig;
 
     if (!originalRequest) {
       return Promise.reject(error);


### PR DESCRIPTION
In GitLab by @BongSangKim on Nov 16, 2024, 19:07

- 제목 : feat(S11P31D206-XXX): 기능명

## :desktop:️ Part

- [x] Frontend
- [ ] Backend

## :pencil: 작업 내용

* 분석페이지에서 종합점수와 색 변경이 안되던 페이지들을 찾아 추가했습니다.
* 잔디 색깔 변경 이스터에그성 기능이 들어갔습니다.
  * 50ms 마다 색이 변경되게 할 수 있습니다.
  * 컴포넌트 언마운트 시 정리 함수로 업데이트 중지됩니다.
  * 메모리 누수 방지 cleanup 처리 되어 이전만큼 느려지지 않습니다
* lazy 로딩 추가 후 로딩과정에서 오류가 있어 lazy로딩을 삭제했습니다.
  * PWA에서 청크 경고 값을 높였습니다. 
  * 실제 build 후 테스트 결과 사용자 경험을 해칠 정도의 로딩이나 느려짐은 없었기에 lazy 로딩을 없애는 것이 이득이라 판단됩니다.
* 강의 페이지를 완성했습니다.
  * ChatGPT를 통해 내 목소리 분석 결과에 따라 학습 방향을 추천해줍니다.
    * 시간을 기준으로 캐싱하여 캐싱되는 동안은 결과를 다시 요청하지 않습니다.
  * Youtube API를 통해 내가 부족한 지표값에 대한 추천 영상을 알려줍니다.
    * 백엔드에서 구현하고 DB에 저장하게 로직을 바꾸었습니다.
      * DB에 미리 저장하여 Get Method로 받음으로서 Youtube API에 직접 요청할 때에 비해 response 시간을 획기적으로 줄입니다.
      * 매우 제한적인 Youtube API 하루 제한값을 아낍니다
        * 백엔드에 미리 저장해두기 때문에 재요청을 원천 방지합니다.